### PR TITLE
refactor: remove default exports & remove import grouping comments

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,22 +1,12 @@
-/**
- * NOTE: You will need to `npm link` zUI before this repo
- * will build or run.
- */
-
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { AppProps } from './lib/types/app';
 
-//- Hook Imports
 import { useDataContainer } from './lib/hooks/useDataContainer';
 
-//- Container Imports
 import { Domains } from './pages/Domains/Domains';
 import { NFT } from './pages/NFT/NFT';
 
-//- Utils Imports
 import { getDomainId } from './lib/util/domains/domains';
 
 export const App: FC<AppProps> = ({ provider, route }) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,13 @@ import { AppProps } from './lib/types/app';
 import { useDataContainer } from './lib/hooks/useDataContainer';
 
 //- Container Imports
-import Domains from './pages/Domains/Domains';
-import NFT from './pages/NFT/NFT';
+import { Domains } from './pages/Domains/Domains';
+import { NFT } from './pages/NFT/NFT';
 
 //- Utils Imports
 import { getDomainId } from './lib/util/domains/domains';
 
-const App: FC<AppProps> = ({ provider, route }) => {
+export const App: FC<AppProps> = ({ provider, route }) => {
 	console.log('prov (marketplace-dapp):', provider);
 	console.log('route (marketplace-dapp):', route);
 
@@ -60,5 +60,3 @@ const App: FC<AppProps> = ({ provider, route }) => {
 		</main>
 	);
 };
-
-export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,8 +4,8 @@ import { AppProps } from './lib/types/app';
 
 import { useDataContainer } from './lib/hooks/useDataContainer';
 
-import { Domains } from './pages/Domains/Domains';
-import { NFT } from './pages/NFT/NFT';
+import { Domains } from './pages/Domains';
+import { NFT } from './pages/NFT';
 
 import { getDomainId } from './lib/util/domains/domains';
 

--- a/src/features/buy-now/BuyNow.tsx
+++ b/src/features/buy-now/BuyNow.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Hooks Imports
 import { useWeb3 } from '../../lib/hooks/useWeb3';
 
-//- Components Imports
 import { ConnectWallet } from '../../features/ui/ConnectWallet';
 
 export const BuyNow: FC = () => {

--- a/src/features/buy-now/BuyNow.tsx
+++ b/src/features/buy-now/BuyNow.tsx
@@ -2,12 +2,12 @@
 import { FC } from 'react';
 
 //- Hooks Imports
-import useWeb3 from '../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../lib/hooks/useWeb3';
 
 //- Components Imports
 import { ConnectWallet } from '../../features/ui/ConnectWallet';
 
-const BuyNow: FC = () => {
+export const BuyNow: FC = () => {
 	const { account } = useWeb3();
 
 	const content = account ? (
@@ -18,5 +18,3 @@ const BuyNow: FC = () => {
 
 	return content;
 };
-
-export default BuyNow;

--- a/src/features/buy-now/BuyNowButton.tsx
+++ b/src/features/buy-now/BuyNowButton.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { BuyNowModal } from './BuyNowModal';
 
 export const BuyNowButton: FC = () => <BuyNowModal trigger={'Buy'} />;

--- a/src/features/buy-now/BuyNowModal.tsx
+++ b/src/features/buy-now/BuyNowModal.tsx
@@ -8,7 +8,7 @@ import { BasicModalProps } from '../../lib/types/ui';
 import { Modal } from '@zero-tech/zui/src/components';
 
 //- Container Imports
-import BuyNow from './BuyNow';
+import { BuyNow } from './BuyNow';
 
 export interface BuyNowModalProps extends BasicModalProps {}
 

--- a/src/features/buy-now/BuyNowModal.tsx
+++ b/src/features/buy-now/BuyNowModal.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { BasicModalProps } from '../../lib/types/ui';
 
-//- Components Imports
 import { Modal } from '@zero-tech/zui/src/components';
 
-//- Container Imports
 import { BuyNow } from './BuyNow';
 
 export interface BuyNowModalProps extends BasicModalProps {}

--- a/src/features/cancel-bid/CancelBid.tsx
+++ b/src/features/cancel-bid/CancelBid.tsx
@@ -2,12 +2,12 @@
 import { FC } from 'react';
 
 //- Hooks Imports
-import useWeb3 from '../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../lib/hooks/useWeb3';
 
 //- Components Imports
 import { ConnectWallet } from '../../features/ui/ConnectWallet';
 
-const CancelBid: FC = () => {
+export const CancelBid: FC = () => {
 	const { account } = useWeb3();
 
 	const content = account ? (
@@ -18,5 +18,3 @@ const CancelBid: FC = () => {
 
 	return content;
 };
-
-export default CancelBid;

--- a/src/features/cancel-bid/CancelBid.tsx
+++ b/src/features/cancel-bid/CancelBid.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Hooks Imports
 import { useWeb3 } from '../../lib/hooks/useWeb3';
 
-//- Components Imports
 import { ConnectWallet } from '../../features/ui/ConnectWallet';
 
 export const CancelBid: FC = () => {

--- a/src/features/cancel-bid/CancelBidButton.tsx
+++ b/src/features/cancel-bid/CancelBidButton.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { CancelBidModal } from './CancelBidModal';
 
 export const CancelBidButton: FC = () => (

--- a/src/features/cancel-bid/CancelBidModal.tsx
+++ b/src/features/cancel-bid/CancelBidModal.tsx
@@ -8,7 +8,7 @@ import { BasicModalProps } from '../../lib/types/ui';
 import { Modal } from '@zero-tech/zui/src/components';
 
 //- Container Imports
-import CancelBid from './CancelBid';
+import { CancelBid } from './CancelBid';
 
 export interface CancelBidModalProps extends BasicModalProps {}
 

--- a/src/features/cancel-bid/CancelBidModal.tsx
+++ b/src/features/cancel-bid/CancelBidModal.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { BasicModalProps } from '../../lib/types/ui';
 
-//- Components Imports
 import { Modal } from '@zero-tech/zui/src/components';
 
-//- Container Imports
 import { CancelBid } from './CancelBid';
 
 export interface CancelBidModalProps extends BasicModalProps {}

--- a/src/features/domain-preview/DomainPreview.tsx
+++ b/src/features/domain-preview/DomainPreview.tsx
@@ -8,7 +8,7 @@ import { truncateAddress } from '../../lib/util/domains/domains';
 //- Constants Imports
 import { AddressTitle } from './DomainPreview.constants';
 
-type PreviewCardProps = {
+type DomainPreviewProps = {
 	title?: string;
 	description?: string;
 	icon?: string;
@@ -19,7 +19,7 @@ type PreviewCardProps = {
 	isNFTView?: boolean;
 };
 
-const ViewContainerNFTCard: FC<PreviewCardProps> = ({
+export const DomainPreview: FC<DomainPreviewProps> = ({
 	title,
 	description,
 	icon,
@@ -62,5 +62,3 @@ const ViewContainerNFTCard: FC<PreviewCardProps> = ({
 		</div>
 	);
 };
-
-export default ViewContainerNFTCard;

--- a/src/features/domain-preview/DomainPreview.tsx
+++ b/src/features/domain-preview/DomainPreview.tsx
@@ -1,11 +1,8 @@
-// React Imports
 import { FC } from 'react';
 import { Link } from 'react-router-dom';
 
-//- Utils Imports
 import { truncateAddress } from '../../lib/util/domains/domains';
 
-//- Constants Imports
 import { AddressTitle } from './DomainPreview.constants';
 
 type DomainPreviewProps = {

--- a/src/features/place-bid/PlaceBid.tsx
+++ b/src/features/place-bid/PlaceBid.tsx
@@ -2,12 +2,12 @@
 import { FC } from 'react';
 
 //- Hooks Imports
-import useWeb3 from '../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../lib/hooks/useWeb3';
 
 //- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
-const PlaceBid: FC = () => {
+export const PlaceBid: FC = () => {
 	const { account } = useWeb3();
 
 	const content = account ? (
@@ -18,5 +18,3 @@ const PlaceBid: FC = () => {
 
 	return content;
 };
-
-export default PlaceBid;

--- a/src/features/place-bid/PlaceBid.tsx
+++ b/src/features/place-bid/PlaceBid.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Hooks Imports
 import { useWeb3 } from '../../lib/hooks/useWeb3';
 
-//- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
 export const PlaceBid: FC = () => {

--- a/src/features/place-bid/PlaceBidButton.tsx
+++ b/src/features/place-bid/PlaceBidButton.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { PlaceBidModal } from './PlaceBidModal';
 
 type PlaceBidButtonProps = {

--- a/src/features/place-bid/PlaceBidModal.tsx
+++ b/src/features/place-bid/PlaceBidModal.tsx
@@ -8,7 +8,7 @@ import { BasicModalProps } from '../../lib/types/ui';
 import { Modal } from '@zero-tech/zui/src/components';
 
 //- Container Imports
-import PlaceBid from './PlaceBid';
+import { PlaceBid } from './PlaceBid';
 
 export interface PlaceBidModalProps extends BasicModalProps {}
 

--- a/src/features/place-bid/PlaceBidModal.tsx
+++ b/src/features/place-bid/PlaceBidModal.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { BasicModalProps } from '../../lib/types/ui';
 
-//- Components Imports
 import { Modal } from '@zero-tech/zui/src/components';
 
-//- Container Imports
 import { PlaceBid } from './PlaceBid';
 
 export interface PlaceBidModalProps extends BasicModalProps {}

--- a/src/features/set-buy-now/SetBuyNow.tsx
+++ b/src/features/set-buy-now/SetBuyNow.tsx
@@ -2,12 +2,12 @@
 import { FC } from 'react';
 
 //- Hooks Imports
-import useWeb3 from '../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../lib/hooks/useWeb3';
 
 //- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
-const SetBuyNow: FC = () => {
+export const SetBuyNow: FC = () => {
 	const { account } = useWeb3();
 
 	const content = account ? (
@@ -18,5 +18,3 @@ const SetBuyNow: FC = () => {
 
 	return content;
 };
-
-export default SetBuyNow;

--- a/src/features/set-buy-now/SetBuyNow.tsx
+++ b/src/features/set-buy-now/SetBuyNow.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Hooks Imports
 import { useWeb3 } from '../../lib/hooks/useWeb3';
 
-//- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
 export const SetBuyNow: FC = () => {

--- a/src/features/set-buy-now/SetBuyNowButton.tsx
+++ b/src/features/set-buy-now/SetBuyNowButton.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { SetBuyNowModal } from './SetBuyNowModal';
 
 export const SetBuyNowButton: FC = () => (

--- a/src/features/set-buy-now/SetBuyNowModal.tsx
+++ b/src/features/set-buy-now/SetBuyNowModal.tsx
@@ -8,7 +8,7 @@ import { BasicModalProps } from '../../lib/types/ui';
 import { Modal } from '@zero-tech/zui/src/components';
 
 //- Container Imports
-import SetBuyNow from './SetBuyNow';
+import { SetBuyNow } from './SetBuyNow';
 
 export interface SetBuyNowModalProps extends BasicModalProps {}
 

--- a/src/features/set-buy-now/SetBuyNowModal.tsx
+++ b/src/features/set-buy-now/SetBuyNowModal.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { BasicModalProps } from '../../lib/types/ui';
 
-//- Components Imports
 import { Modal } from '@zero-tech/zui/src/components';
 
-//- Container Imports
 import { SetBuyNow } from './SetBuyNow';
 
 export interface SetBuyNowModalProps extends BasicModalProps {}

--- a/src/features/ui/ConnectWallet/ConnectWallet.tsx
+++ b/src/features/ui/ConnectWallet/ConnectWallet.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-import useWeb3 from '../../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../../lib/hooks/useWeb3';
 
 import { Button } from '@zero-tech/zui/src/components';
 

--- a/src/features/ui/StatsList/StatsList.tsx
+++ b/src/features/ui/StatsList/StatsList.tsx
@@ -22,16 +22,12 @@ type StatsListProps = {
 	stats: Stat[];
 };
 
-const StatsList: FC<StatsListProps> = ({ stats }) => (
-	<div className={styles.Stats}>
+export const StatsList: FC<StatsListProps> = ({ stats }) => (
+	<ul className={styles.Stats} style={{ listStyle: 'none', padding: '0' }}>
 		{stats.map((stat: Stat, index) => (
-			<ul style={{ listStyle: 'none', padding: '0' }}>
-				<li key={`stat-${index}`}>
-					<Card title={stat.title} value={stat.value} bottomText={stat.text} />
-				</li>
-			</ul>
+			<li key={`stat-${index}`}>
+				<Card title={stat.title} value={stat.value} bottomText={stat.text} />
+			</li>
 		))}
-	</div>
+	</ul>
 );
-
-export default StatsList;

--- a/src/features/ui/StatsList/StatsList.tsx
+++ b/src/features/ui/StatsList/StatsList.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC, ReactNode } from 'react';
 
-//- Components Improts
 import { Card } from '@zero-tech/zui/src/components';
 
-//- Style Imports
 import styles from './StatsList.module.scss';
 
 type Text = {

--- a/src/features/ui/TableCard/TableCard.tsx
+++ b/src/features/ui/TableCard/TableCard.tsx
@@ -15,7 +15,7 @@ type TableCardProps = {
 	onClick?: (event?: any) => void;
 };
 
-const TableCard: FC<TableCardProps> = ({
+export const TableCard: FC<TableCardProps> = ({
 	children,
 	header,
 	subHeader,
@@ -32,5 +32,3 @@ const TableCard: FC<TableCardProps> = ({
 		</div>
 	);
 };
-
-export default TableCard;

--- a/src/features/ui/TableCard/TableCard.tsx
+++ b/src/features/ui/TableCard/TableCard.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import type { FC, ReactNode } from 'react';
 
-//- Styles Imports
 import styles from './TableCard.module.scss';
 import classNames from 'classnames/bind';
 

--- a/src/features/view-bids/ViewBids.tsx
+++ b/src/features/view-bids/ViewBids.tsx
@@ -2,12 +2,12 @@
 import { FC } from 'react';
 
 //- Hooks Imports
-import useWeb3 from '../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../lib/hooks/useWeb3';
 
 //- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
-const ViewBids: FC = () => {
+export const ViewBids: FC = () => {
 	const { account } = useWeb3();
 
 	const content = account ? (
@@ -18,5 +18,3 @@ const ViewBids: FC = () => {
 
 	return content;
 };
-
-export default ViewBids;

--- a/src/features/view-bids/ViewBids.tsx
+++ b/src/features/view-bids/ViewBids.tsx
@@ -1,10 +1,7 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Hooks Imports
 import { useWeb3 } from '../../lib/hooks/useWeb3';
 
-//- Components Imports
 import { ConnectWallet } from '../ui/ConnectWallet';
 
 export const ViewBids: FC = () => {

--- a/src/features/view-bids/ViewBidsButton.tsx
+++ b/src/features/view-bids/ViewBidsButton.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { ViewBidsModal } from './ViewBidsModal';
 
 export const ViewBidsButton: FC = () => <ViewBidsModal trigger={'View Bids'} />;

--- a/src/features/view-bids/ViewBidsModal.tsx
+++ b/src/features/view-bids/ViewBidsModal.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { BasicModalProps } from '../../lib/types/ui';
 
-//- Components Imports
 import { Modal } from '@zero-tech/zui/src/components';
 
-//- Container Imports
 import { ViewBids } from './ViewBids';
 
 export interface ViewBidsModalProps extends BasicModalProps {}

--- a/src/features/view-bids/ViewBidsModal.tsx
+++ b/src/features/view-bids/ViewBidsModal.tsx
@@ -8,7 +8,7 @@ import { BasicModalProps } from '../../lib/types/ui';
 import { Modal } from '@zero-tech/zui/src/components';
 
 //- Container Imports
-import ViewBids from './ViewBids';
+import { ViewBids } from './ViewBids';
 
 export interface ViewBidsModalProps extends BasicModalProps {}
 

--- a/src/features/view-nft/Action/Action.tsx
+++ b/src/features/view-nft/Action/Action.tsx
@@ -1,7 +1,5 @@
-//- React Imports
 import { ReactNode } from 'react';
 
-//- Styles Imports
 import styles from './Action.module.scss';
 
 type ActionProps = {

--- a/src/features/view-nft/Action/Action.tsx
+++ b/src/features/view-nft/Action/Action.tsx
@@ -11,7 +11,7 @@ type ActionProps = {
 	buttonComponent: ReactNode;
 };
 
-const Action = ({
+export const Action = ({
 	label,
 	amountToken,
 	amountUsd,
@@ -24,5 +24,3 @@ const Action = ({
 		<div className={styles.Button}>{buttonComponent}</div>
 	</div>
 );
-
-export default Action;

--- a/src/features/view-nft/Actions/Actions.tsx
+++ b/src/features/view-nft/Actions/Actions.tsx
@@ -2,7 +2,7 @@
 import { Domain, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
 //- Components Imports
-import Action from '../Action/Action';
+import { Action } from '../Action/Action';
 import { BuyNowButton } from '../../buy-now';
 import { SetBuyNowButton } from '../../set-buy-now';
 import { PlaceBidButton } from '../../place-bid';
@@ -14,7 +14,7 @@ import { DataTestId, Messages } from './Actions.constants';
 import { Labels } from '../../../lib/constants/labels';
 
 //- Hooks Imports
-import useWeb3 from '../../../lib/hooks/useWeb3';
+import { useWeb3 } from '../../../lib/hooks/useWeb3';
 import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 import { useBidData } from '../../../lib/hooks/useBidData';
 
@@ -40,7 +40,7 @@ type ActionsProps = {
 	paymentTokenInfo?: TokenPriceInfo;
 };
 
-const Actions = ({
+export const Actions = ({
 	domain,
 	domainMetadata,
 	paymentTokenInfo,
@@ -131,5 +131,3 @@ const Actions = ({
 		</ul>
 	);
 };
-
-export default Actions;

--- a/src/features/view-nft/Actions/Actions.tsx
+++ b/src/features/view-nft/Actions/Actions.tsx
@@ -1,7 +1,5 @@
-//- Library Imports
 import { Domain, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Components Imports
 import { Action } from '../Action/Action';
 import { BuyNowButton } from '../../buy-now';
 import { SetBuyNowButton } from '../../set-buy-now';
@@ -9,16 +7,13 @@ import { PlaceBidButton } from '../../place-bid';
 import { ViewBidsButton } from '../../view-bids';
 import { CancelBidButton } from '../../cancel-bid';
 
-//- Constants Imports
 import { DataTestId, Messages } from './Actions.constants';
 import { Labels } from '../../../lib/constants/labels';
 
-//- Hooks Imports
 import { useWeb3 } from '../../../lib/hooks/useWeb3';
 import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 import { useBidData } from '../../../lib/hooks/useBidData';
 
-//- Utils Imports
 import {
 	getOrderedActions,
 	getUsdConversion,
@@ -27,11 +22,9 @@ import {
 import { formatNumber } from '../../../lib/util/number/number';
 import { getHighestBid, getUserBids } from '../../../lib/util/bids/bids';
 
-//- Types Imports
 import { ActionBlock, ActionTypes } from './Actions.types';
 import { Metadata } from '../../../lib/types/metadata';
 
-// Styles
 import styles from './Actions.module.scss';
 
 type ActionsProps = {

--- a/src/features/view-nft/Actions/Actions.types.ts
+++ b/src/features/view-nft/Actions/Actions.types.ts
@@ -1,4 +1,3 @@
-//- React Imports
 import { ReactNode } from 'react';
 
 export enum ActionTypes {

--- a/src/features/view-nft/Actions/Actions.utils.ts
+++ b/src/features/view-nft/Actions/Actions.utils.ts
@@ -1,19 +1,6 @@
-//- Types Imports
 import { ActionBlock, ActionTypes } from './Actions.types';
 
-//- Utils Imports
 import { formatNumber } from '../../../lib/util/number/number';
-
-// const actions = {
-// 	owner: [ActionTypes.BID, ActionTypes.BUY_NOW, ActionTypes.SET_BUY_NOW],
-// 	viewer: [ActionTypes.BUY_NOW, ActionTypes.BID, ActionTypes.USER_BID],
-// };
-
-// export const getOrderedActions = (isOwnedByUser: boolean) =>
-// 	isOwnedByUser ? actions['owner'] : actions['viewer'];
-
-// export const getVisibleActions = (actions: ActionBlock[]) =>
-// 	actions.filter((action) => Boolean(action.isVisible));
 
 export const getOrderedActions = (
 	isOwnedByUser: boolean,

--- a/src/features/view-nft/HistoryItem/HistoryItem.tsx
+++ b/src/features/view-nft/HistoryItem/HistoryItem.tsx
@@ -1,7 +1,5 @@
-//- Types Imports
 import { DomainEvent } from '../../../lib/types/events';
 
-//- Library Imports
 import moment from 'moment';
 import {
 	DomainBidEvent,
@@ -13,7 +11,6 @@ import {
 	TokenPriceInfo,
 } from '@zero-tech/zns-sdk';
 
-//- Utils Imports
 import { truncateAddress } from '../../../lib/util/domains/domains';
 import { formatEthers } from '../../../lib/util/number/number';
 

--- a/src/features/view-nft/HistoryItem/HistoryItem.tsx
+++ b/src/features/view-nft/HistoryItem/HistoryItem.tsx
@@ -22,7 +22,7 @@ type HistoryItemProps = {
 	paymentToken: TokenPriceInfo;
 };
 
-const HistoryItem = ({ item, paymentToken }: HistoryItemProps) => {
+export const HistoryItem = ({ item, paymentToken }: HistoryItemProps) => {
 	switch (item.type) {
 		case DomainEventType.bid:
 			item = item as DomainBidEvent;
@@ -220,5 +220,3 @@ const HistoryItem = ({ item, paymentToken }: HistoryItemProps) => {
 			return <></>;
 	}
 };
-
-export default HistoryItem;

--- a/src/features/view-nft/HistoryList/HistoryList.tsx
+++ b/src/features/view-nft/HistoryList/HistoryList.tsx
@@ -1,19 +1,13 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Library Imports
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Component Imports
 import { HistoryItem } from '../HistoryItem/HistoryItem';
 
-//- Types Imports
 import { DomainEvent } from '../../../lib/types/events';
 
-//- Hooks Imports
 import { useDomainEvents } from '../../../lib/hooks/useDomainEvents';
 
-//- Utils Imports
 import { sortEventsByTimestamp } from './HistoryList.utils';
 
 type HistoryListProps = {

--- a/src/features/view-nft/HistoryList/HistoryList.tsx
+++ b/src/features/view-nft/HistoryList/HistoryList.tsx
@@ -5,7 +5,7 @@ import { FC } from 'react';
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
 
 //- Component Imports
-import HistoryItem from '../HistoryItem/HistoryItem';
+import { HistoryItem } from '../HistoryItem/HistoryItem';
 
 //- Types Imports
 import { DomainEvent } from '../../../lib/types/events';
@@ -21,7 +21,10 @@ type HistoryListProps = {
 	paymentToken: TokenPriceInfo;
 };
 
-const HistoryList: FC<HistoryListProps> = ({ domainId, paymentToken }) => {
+export const HistoryList: FC<HistoryListProps> = ({
+	domainId,
+	paymentToken,
+}) => {
 	const { data: domainEvents } = useDomainEvents(domainId);
 	const sortedDomainEvents = sortEventsByTimestamp(domainEvents);
 
@@ -41,5 +44,3 @@ const HistoryList: FC<HistoryListProps> = ({ domainId, paymentToken }) => {
 		</section>
 	);
 };
-
-export default HistoryList;

--- a/src/features/view-nft/HistoryList/HistoryList.utils.ts
+++ b/src/features/view-nft/HistoryList/HistoryList.utils.ts
@@ -1,7 +1,5 @@
-//- Library Imports
 import { DomainEventType } from '@zero-tech/zns-sdk';
 
-//- Types Imports
 import { DomainEvent } from '../../../lib/types/events';
 
 export const sortEventsByTimestamp = (

--- a/src/features/view-nft/NFTMetrics/NFTMetrics.tsx
+++ b/src/features/view-nft/NFTMetrics/NFTMetrics.tsx
@@ -2,7 +2,7 @@
 import { FC } from 'react';
 
 //- Features Imports
-import StatsList from '../../ui/StatsList/StatsList';
+import { StatsList } from '../../ui/StatsList/StatsList';
 
 //- Library Imports
 import { ethers } from 'ethers';
@@ -21,7 +21,7 @@ type NFTMetricsProps = {
 	paymentTokenInfo: TokenPriceInfo;
 };
 
-const NFTMetrics: FC<NFTMetricsProps> = ({
+export const NFTMetrics: FC<NFTMetricsProps> = ({
 	domainId,
 	metrics,
 	isLoading,
@@ -63,5 +63,3 @@ const NFTMetrics: FC<NFTMetricsProps> = ({
 
 	return <StatsList stats={stats} />;
 };
-
-export default NFTMetrics;

--- a/src/features/view-nft/NFTMetrics/NFTMetrics.tsx
+++ b/src/features/view-nft/NFTMetrics/NFTMetrics.tsx
@@ -1,17 +1,12 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Features Imports
 import { StatsList } from '../../ui/StatsList/StatsList';
 
-//- Library Imports
 import { ethers } from 'ethers';
 import { DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Hooks Imports
 import { useBidData } from '../../../lib/hooks/useBidData';
 
-//- Utils Imports
 import { formatEthers, formatNumber } from '../../../lib/util/number/number';
 
 type NFTMetricsProps = {

--- a/src/features/view-nft/TokenHashInfo/TokenHashInfo.tsx
+++ b/src/features/view-nft/TokenHashInfo/TokenHashInfo.tsx
@@ -1,13 +1,9 @@
-//- React Imports
 import { FC, useMemo } from 'react';
 
-//- Library Imports
 import { Domain } from '@zero-tech/zns-sdk';
 
-//- Features Imports
 import { StatsList } from '../../ui/StatsList/StatsList';
 
-//- Utils Imports
 import { truncateAddress } from '../../../lib/util/domains/domains';
 import { getHashFromIPFSUrl } from '../../../lib/util/ipfs.ts/ipfs';
 

--- a/src/features/view-nft/TokenHashInfo/TokenHashInfo.tsx
+++ b/src/features/view-nft/TokenHashInfo/TokenHashInfo.tsx
@@ -5,7 +5,7 @@ import { FC, useMemo } from 'react';
 import { Domain } from '@zero-tech/zns-sdk';
 
 //- Features Imports
-import StatsList from '../../ui/StatsList/StatsList';
+import { StatsList } from '../../ui/StatsList/StatsList';
 
 //- Utils Imports
 import { truncateAddress } from '../../../lib/util/domains/domains';
@@ -15,7 +15,7 @@ type TokenHashInfoProps = {
 	domain: Domain;
 };
 
-const TokenHashInfo: FC<TokenHashInfoProps> = ({ domain }) => {
+export const TokenHashInfo: FC<TokenHashInfoProps> = ({ domain }) => {
 	const ipfsHash = domain ? getHashFromIPFSUrl(domain?.metadataUri) : '';
 
 	const stats = [
@@ -37,5 +37,3 @@ const TokenHashInfo: FC<TokenHashInfoProps> = ({ domain }) => {
 		</div>
 	);
 };
-
-export default TokenHashInfo;

--- a/src/features/view-subdomains/SubdomainMetrics/SubdomainMetrics.tsx
+++ b/src/features/view-subdomains/SubdomainMetrics/SubdomainMetrics.tsx
@@ -1,14 +1,10 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Library Imports
 import { ethers } from 'ethers';
 import { DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Features Imports
 import { StatsList } from '../../ui/StatsList/StatsList';
 
-//- Utils Imports
 import { formatEthers, formatNumber } from '../../../lib/util/number/number';
 
 interface SubdomainMetricsProps {

--- a/src/features/view-subdomains/SubdomainMetrics/SubdomainMetrics.tsx
+++ b/src/features/view-subdomains/SubdomainMetrics/SubdomainMetrics.tsx
@@ -6,7 +6,7 @@ import { ethers } from 'ethers';
 import { DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
 //- Features Imports
-import StatsList from '../../ui/StatsList/StatsList';
+import { StatsList } from '../../ui/StatsList/StatsList';
 
 //- Utils Imports
 import { formatEthers, formatNumber } from '../../../lib/util/number/number';
@@ -16,7 +16,7 @@ interface SubdomainMetricsProps {
 	paymentTokenInfo: TokenPriceInfo;
 }
 
-const SubdomainMetrics: FC<SubdomainMetricsProps> = ({
+export const SubdomainMetrics: FC<SubdomainMetricsProps> = ({
 	metrics,
 	paymentTokenInfo,
 }) => {
@@ -56,5 +56,3 @@ const SubdomainMetrics: FC<SubdomainMetricsProps> = ({
 
 	return <StatsList stats={stats} />;
 };
-
-export default SubdomainMetrics;

--- a/src/features/view-subdomains/SubdomainTable.constants.ts
+++ b/src/features/view-subdomains/SubdomainTable.constants.ts
@@ -1,4 +1,3 @@
-//- Components Imports
 import { Column } from '@zero-tech/zui/src/components/AsyncTable';
 
 export const COLUMNS: Column[] = [

--- a/src/features/view-subdomains/SubdomainTable/SubdomainTable.tsx
+++ b/src/features/view-subdomains/SubdomainTable/SubdomainTable.tsx
@@ -7,8 +7,8 @@ import { Domain, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
 //- Components Imports
 import { AsyncTable } from '@zero-tech/zui/src/components';
-import SubdomainTableCard from '../SubdomainTableCard/SubdomainTableCard';
-import SubdomainTableRow from '../SubdomainTableRow/SubdomainTableRow';
+import { SubdomainTableCard } from '../SubdomainTableCard/SubdomainTableCard';
+import { SubdomainTableRow } from '../SubdomainTableRow/SubdomainTableRow';
 
 //- Constants Imports
 import { COLUMNS } from '../SubdomainTable.constants';
@@ -19,7 +19,7 @@ type SubdomainTableProps = {
 	isSubdomainDataLoading?: boolean;
 };
 
-const SubdomainTable: FC<SubdomainTableProps> = ({
+export const SubdomainTable: FC<SubdomainTableProps> = ({
 	subdomainData,
 	paymentTokenData,
 	isSubdomainDataLoading,
@@ -86,5 +86,3 @@ const SubdomainTable: FC<SubdomainTableProps> = ({
 		</>
 	);
 };
-
-export default memo(SubdomainTable);

--- a/src/features/view-subdomains/SubdomainTable/SubdomainTable.tsx
+++ b/src/features/view-subdomains/SubdomainTable/SubdomainTable.tsx
@@ -1,16 +1,12 @@
-//- React Imports
-import { FC, memo, useCallback, useState } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { useHistory } from 'react-router-dom';
 
-//- Library Imports
 import { Domain, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Components Imports
 import { AsyncTable } from '@zero-tech/zui/src/components';
 import { SubdomainTableCard } from '../SubdomainTableCard/SubdomainTableCard';
 import { SubdomainTableRow } from '../SubdomainTableRow/SubdomainTableRow';
 
-//- Constants Imports
 import { COLUMNS } from '../SubdomainTable.constants';
 
 type SubdomainTableProps = {

--- a/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
+++ b/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
@@ -1,22 +1,17 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Library Imports
 import { ethers } from 'ethers';
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Hook Imports
 import { useDomainMetadata } from '../../../lib/hooks/useDomainMetadata';
 import { useDomainMetrics } from '../../../lib/hooks/useDomainMetrics';
 import { formatEthers, formatNumber } from '../../../lib/util/number/number';
 import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 
-//- Component Imports
 import { PlaceBidButton } from '../../place-bid';
 import { BuyNowButton } from '../../buy-now';
 import { TableCard } from '../../ui/TableCard/TableCard';
 
-//-Styles Imports
 import styles from './SubdomainTableCard.module.scss';
 
 type SubdomainTableCardProps = {

--- a/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
+++ b/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
@@ -14,7 +14,7 @@ import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 //- Component Imports
 import { PlaceBidButton } from '../../place-bid';
 import { BuyNowButton } from '../../buy-now';
-import TableCard from '../../ui/TableCard/TableCard';
+import { TableCard } from '../../ui/TableCard/TableCard';
 
 //-Styles Imports
 import styles from './SubdomainTableCard.module.scss';
@@ -27,7 +27,7 @@ type SubdomainTableCardProps = {
 	onCardClick: (e?: any, domainName?: string) => void;
 };
 
-const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
+export const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 	domainId,
 	domainName,
 	domainMetadataUri,
@@ -70,5 +70,3 @@ const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 		</TableCard>
 	);
 };
-
-export default SubdomainTableCard;

--- a/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
+++ b/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
@@ -23,7 +23,7 @@ type SubdomainTableRowProps = {
 	onRowClick: (e?: any, domainName?: string) => void;
 };
 
-const SubdomainTableRow: FC<SubdomainTableRowProps> = ({
+export const SubdomainTableRow: FC<SubdomainTableRowProps> = ({
 	domainId,
 	domainName,
 	domainMetadataUri,
@@ -69,5 +69,3 @@ const SubdomainTableRow: FC<SubdomainTableRowProps> = ({
 		</>
 	);
 };
-
-export default SubdomainTableRow;

--- a/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
+++ b/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
@@ -1,17 +1,13 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Library Imports
 import { ethers } from 'ethers';
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Hook Imports
 import { useDomainMetadata } from '../../../lib/hooks/useDomainMetadata';
 import { useDomainMetrics } from '../../../lib/hooks/useDomainMetrics';
 import { formatEthers, formatNumber } from '../../../lib/util/number/number';
 import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 
-//- Component Imports
 import { PlaceBidButton } from '../../place-bid';
 import { BuyNowButton } from '../../buy-now';
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,23 +1,12 @@
-/**
- * This file:
- * - Wraps out App in necessary context providers
- * - Exports the root component
- */
-
-//- React Imports
 import { QueryClient, QueryClientProvider } from 'react-query';
 
-//- Type Imports
 import { AppProps } from './lib/types/app';
 
-//- Utils Imports
 import { ChainGate } from './lib/util/ChainGate';
 
-//- Provider Imports
 import { Web3Provider } from './lib/providers/Web3Provider';
 import { ZnsSdkProvider } from './lib/providers/ZnsSdkProvider';
 
-//- Container Imports
 import { App } from './App';
 
 const queryClient = new QueryClient();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,18 +11,18 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { AppProps } from './lib/types/app';
 
 //- Utils Imports
-import ChainGate from './lib/util/ChainGate';
+import { ChainGate } from './lib/util/ChainGate';
 
 //- Provider Imports
-import Web3Provider from './lib/providers/Web3Provider';
-import ZnsSdkProvider from './lib/providers/ZnsSdkProvider';
+import { Web3Provider } from './lib/providers/Web3Provider';
+import { ZnsSdkProvider } from './lib/providers/ZnsSdkProvider';
 
 //- Container Imports
-import App from './App';
+import { App } from './App';
 
 const queryClient = new QueryClient();
 
-const Index = ({ provider, route, web3 }: AppProps) => (
+export const Index = ({ provider, route, web3 }: AppProps) => (
 	<QueryClientProvider client={queryClient}>
 		<Web3Provider
 			provider={provider}
@@ -38,5 +38,3 @@ const Index = ({ provider, route, web3 }: AppProps) => (
 		</Web3Provider>
 	</QueryClientProvider>
 );
-
-export default Index;

--- a/src/lib/constants/networks.ts
+++ b/src/lib/constants/networks.ts
@@ -11,11 +11,6 @@ export enum NETWORK_TYPES {
 
 const ENV_NETWORK = process.env.REACT_APP_DEFAULT_NETWORK;
 export const DEFAULT_NETWORK = Network.RINKEBY;
-// export const DEFAULT_NETWORK: Network = (
-//   ENV_NETWORK && typeof ENV_NETWORK === "number" && Network[ENV_NETWORK]
-//     ? Network[ENV_NETWORK]
-//     : Network.MAINNET
-// ) as Network;
 
 interface NetworkConfig {
 	rpcUrl: string;

--- a/src/lib/hooks/useBidData.ts
+++ b/src/lib/hooks/useBidData.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useBidData = (domainId: string) => {

--- a/src/lib/hooks/useBuyNowPrice.ts
+++ b/src/lib/hooks/useBuyNowPrice.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useBuyNowPrice = (domainId: string) => {

--- a/src/lib/hooks/useDataContainer.ts
+++ b/src/lib/hooks/useDataContainer.ts
@@ -1,4 +1,3 @@
-//- Hook Imports
 import { useSubdomainData } from './useSubdomainData';
 import { useDomainData } from './useDomainData';
 import { usePaymentTokenInfo } from './usePaymentTokenInfo';

--- a/src/lib/hooks/useDomainData.ts
+++ b/src/lib/hooks/useDomainData.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useDomainData = (domainId: string) => {

--- a/src/lib/hooks/useDomainEvents.ts
+++ b/src/lib/hooks/useDomainEvents.ts
@@ -1,10 +1,7 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Types Imports
 import { DomainEvent } from '../../lib/types/events';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useDomainEvents = (domainId: string) => {

--- a/src/lib/hooks/useDomainMetadata.ts
+++ b/src/lib/hooks/useDomainMetadata.ts
@@ -1,10 +1,7 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Util Imports
 import { parseDomainMetadata } from '../util/metadata/metadata';
 
-//- Library Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useDomainMetadata = (uri: string) => {

--- a/src/lib/hooks/useDomainMetadata.ts
+++ b/src/lib/hooks/useDomainMetadata.ts
@@ -5,7 +5,7 @@ import { useQuery } from 'react-query';
 import { parseDomainMetadata } from '../util/metadata/metadata';
 
 //- Library Imports
-import useZnsSdk from './useZnsSdk';
+import { useZnsSdk } from './useZnsSdk';
 
 export const useDomainMetadata = (uri: string) => {
 	const sdk = useZnsSdk();

--- a/src/lib/hooks/useDomainMetrics.ts
+++ b/src/lib/hooks/useDomainMetrics.ts
@@ -1,8 +1,6 @@
-//- React Imports
 import { DomainMetricsCollection } from '@zero-tech/zns-sdk';
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useDomainMetrics = (domainId: string) => {

--- a/src/lib/hooks/usePaymentTokenForDomain.ts
+++ b/src/lib/hooks/usePaymentTokenForDomain.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const usePaymentTokenForDomain = (domainId: string) => {

--- a/src/lib/hooks/usePaymentTokenInfo.ts
+++ b/src/lib/hooks/usePaymentTokenInfo.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const usePaymentTokenInfo = (token: string) => {

--- a/src/lib/hooks/useSubdomainData.ts
+++ b/src/lib/hooks/useSubdomainData.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useQuery } from 'react-query';
 
-//- Hooks Imports
 import { useZnsSdk } from './useZnsSdk';
 
 export const useSubdomainData = (domainId: string) => {

--- a/src/lib/hooks/useViewNavigation.ts
+++ b/src/lib/hooks/useViewNavigation.ts
@@ -1,8 +1,6 @@
-//- React Imports
 import { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 
-//- Library Imports
 import { Domain } from '@zero-tech/zns-sdk';
 
 type UseBrowserNavigationReturn = {

--- a/src/lib/hooks/useWeb3.ts
+++ b/src/lib/hooks/useWeb3.ts
@@ -4,4 +4,3 @@ import { Web3Context } from '../providers/Web3Provider';
 export function useWeb3() {
 	return useContext(Web3Context);
 }
-export default useWeb3;

--- a/src/lib/hooks/useZnsSdk.ts
+++ b/src/lib/hooks/useZnsSdk.ts
@@ -1,7 +1,5 @@
-//- React Imports
 import { useContext } from 'react';
 
-//- Library Imports
 import { ZnsSdkContext } from '../providers/ZnsSdkProvider';
 
 export function useZnsSdk() {

--- a/src/lib/hooks/useZnsSdk.ts
+++ b/src/lib/hooks/useZnsSdk.ts
@@ -7,4 +7,3 @@ import { ZnsSdkContext } from '../providers/ZnsSdkProvider';
 export function useZnsSdk() {
 	return useContext(ZnsSdkContext);
 }
-export default useZnsSdk;

--- a/src/lib/providers/Web3Provider.tsx
+++ b/src/lib/providers/Web3Provider.tsx
@@ -19,7 +19,7 @@ export const Web3Context = createContext({
 /**
  * Exposes wallet information received by zOS to all children.
  */
-const Web3Provider: FC<Web3ProviderProps> = ({
+export const Web3Provider: FC<Web3ProviderProps> = ({
 	account,
 	chainId,
 	connectWallet,
@@ -39,5 +39,3 @@ const Web3Provider: FC<Web3ProviderProps> = ({
 		</Web3Context.Provider>
 	);
 };
-
-export default Web3Provider;

--- a/src/lib/providers/ZnsSdkProvider.tsx
+++ b/src/lib/providers/ZnsSdkProvider.tsx
@@ -1,12 +1,9 @@
-//- React Imports
 import { createContext, FC, ReactNode, useMemo } from 'react';
 
-//- Library Imports
 import { providers } from 'ethers';
 import { chainIdToNetworkType } from '../../lib/helpers/network';
 import * as zns from '@zero-tech/zns-sdk';
 
-//- Constants Imports
 import {
 	DEFAULT_NETWORK,
 	Network,

--- a/src/lib/providers/ZnsSdkProvider.tsx
+++ b/src/lib/providers/ZnsSdkProvider.tsx
@@ -31,7 +31,7 @@ export const ZnsSdkContext = createContext(
 	),
 );
 
-const ZnsSdkProvider: FC<ZnsSdkProviderProps> = ({
+export const ZnsSdkProvider: FC<ZnsSdkProviderProps> = ({
 	provider: providerProps,
 	chainId,
 	children,
@@ -71,5 +71,3 @@ const ZnsSdkProvider: FC<ZnsSdkProviderProps> = ({
 		<ZnsSdkContext.Provider value={sdk}>{children}</ZnsSdkContext.Provider>
 	);
 };
-
-export default ZnsSdkProvider;

--- a/src/lib/types/ui.ts
+++ b/src/lib/types/ui.ts
@@ -1,4 +1,3 @@
-//- Components Imports
 import { ModalProps } from '@zero-tech/zui/src/components/Modal';
 
 export interface BasicModalProps {

--- a/src/lib/util/ChainGate.tsx
+++ b/src/lib/util/ChainGate.tsx
@@ -6,7 +6,7 @@ interface ChainGateProps {
 	children: ReactNode;
 }
 
-const ChainGate: FC<ChainGateProps> = ({ chainId, children }) => {
+export const ChainGate: FC<ChainGateProps> = ({ chainId, children }) => {
 	const isSupportedNetwork = Object.values(Network).includes(chainId);
 
 	if (!isSupportedNetwork) {
@@ -20,5 +20,3 @@ const ChainGate: FC<ChainGateProps> = ({ chainId, children }) => {
 
 	return <>{children}</>;
 };
-
-export default ChainGate;

--- a/src/lib/util/bids/bids.ts
+++ b/src/lib/util/bids/bids.ts
@@ -1,7 +1,5 @@
-//- Library Imports
 import { Bid } from '@zero-tech/zns-sdk/lib/zAuction';
 
-//- Utils Imports
 import { formatEthers } from '../../../lib/util/number/number';
 
 export const getHighestBid = (bids: Bid[]) =>

--- a/src/lib/util/domains/domains.test.ts
+++ b/src/lib/util/domains/domains.test.ts
@@ -1,7 +1,5 @@
-//- Utils Imports
 import { getDomainId, truncateAddress } from './domains';
 
-//- Mocks Imports
 import { rootDomainId, wilderDomainId } from './mocks';
 
 //////////////////////

--- a/src/lib/util/domains/domains.ts
+++ b/src/lib/util/domains/domains.ts
@@ -1,4 +1,3 @@
-//- Library Imports
 import { ethers } from 'ethers';
 
 export const rootDomainId = ethers.constants.HashZero;

--- a/src/lib/util/domains/mocks.ts
+++ b/src/lib/util/domains/mocks.ts
@@ -1,4 +1,3 @@
-//- Library Imports
 import { ethers } from 'ethers';
 
 export const rootDomainId = ethers.constants.HashZero;

--- a/src/lib/util/ipfs.ts/ipfs.test.ts
+++ b/src/lib/util/ipfs.ts/ipfs.test.ts
@@ -1,7 +1,5 @@
-//- Utils Imports
 import { getHashFromIPFSUrl } from './ipfs';
 
-//- Mocks Imports
 import { HASH } from './mocks';
 
 ////////////////////////////

--- a/src/lib/util/metadata/metadata.test.ts
+++ b/src/lib/util/metadata/metadata.test.ts
@@ -1,7 +1,5 @@
-//- Utils Imports
 import { parseDomainMetadata } from './metadata';
 
-//- Mocks Imports
 import * as mocks from './mocks';
 
 /////////////////////////////

--- a/src/lib/util/metadata/metadata.ts
+++ b/src/lib/util/metadata/metadata.ts
@@ -1,7 +1,5 @@
-//- Library Imports
 import { DomainMetadata } from '@zero-tech/zns-sdk/lib/types';
 
-//- Types Imports
 import { Metadata } from '../../types/metadata';
 
 export const parseDomainMetadata = (

--- a/src/lib/util/number/number.test.ts
+++ b/src/lib/util/number/number.test.ts
@@ -1,7 +1,5 @@
-//- Utils Imports
 import { formatEthers, formatNumber } from './number';
 
-//- Mocks Imports
 import { mockMetricsData } from './mocks';
 
 //////////////////////

--- a/src/lib/util/number/number.ts
+++ b/src/lib/util/number/number.ts
@@ -1,4 +1,3 @@
-//- Lib Imports
 import { ethers } from 'ethers';
 
 export const formatNumber = (number: number | string) => {

--- a/src/pages/Domains/Domains.tsx
+++ b/src/pages/Domains/Domains.tsx
@@ -1,15 +1,11 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Types Imports
 import { Metadata } from '../../lib/types/metadata';
 
-//- Features Imports
 import { SubdomainTable } from '../../features/view-subdomains/SubdomainTable/SubdomainTable';
 import { SubdomainMetrics } from '../../features/view-subdomains/SubdomainMetrics/SubdomainMetrics';
 import { DomainPreview } from '../../features/domain-preview/DomainPreview';
 
-//- Library Imports
 import { Domain, DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
 type DomainsProps = {

--- a/src/pages/Domains/Domains.tsx
+++ b/src/pages/Domains/Domains.tsx
@@ -5,14 +5,14 @@ import { FC } from 'react';
 import { Metadata } from '../../lib/types/metadata';
 
 //- Features Imports
-import SubdomainTable from '../../features/view-subdomains/SubdomainTable/SubdomainTable';
-import SubdomainMetrics from '../../features/view-subdomains/SubdomainMetrics/SubdomainMetrics';
-import DomainPreview from '../../features/domain-preview/DomainPreview';
+import { SubdomainTable } from '../../features/view-subdomains/SubdomainTable/SubdomainTable';
+import { SubdomainMetrics } from '../../features/view-subdomains/SubdomainMetrics/SubdomainMetrics';
+import { DomainPreview } from '../../features/domain-preview/DomainPreview';
 
 //- Library Imports
 import { Domain, DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-type DomainsContainerProps = {
+type DomainsProps = {
 	route: string;
 	domain: Domain;
 	metrics: DomainMetrics;
@@ -22,7 +22,7 @@ type DomainsContainerProps = {
 	isSubdomainDataLoading?: boolean;
 };
 
-const DomainsContainer: FC<DomainsContainerProps> = ({
+export const Domains: FC<DomainsProps> = ({
 	route,
 	domain,
 	metrics,
@@ -53,5 +53,3 @@ const DomainsContainer: FC<DomainsContainerProps> = ({
 		</>
 	);
 };
-
-export default DomainsContainer;

--- a/src/pages/Domains/index.ts
+++ b/src/pages/Domains/index.ts
@@ -1,0 +1,1 @@
+export * from './Domains';

--- a/src/pages/NFT/NFT.tsx
+++ b/src/pages/NFT/NFT.tsx
@@ -2,15 +2,11 @@
 import { FC } from 'react';
 
 //- Components Imports
-import HistoryList from '../../features/view-nft/HistoryList/HistoryList';
-import TokenHashInfo from '../../features/view-nft/TokenHashInfo/TokenHashInfo';
-import NFTMetrics from '../../features/view-nft/NFTMetrics/NFTMetrics';
-import DomainPreview from '../../features/domain-preview/DomainPreview';
-import Actions from '../../features/view-nft/Actions/Actions';
-
-//- Hooks Imports
-import { useDomainEvents } from '../../lib/hooks/useDomainEvents';
-import { useBidData } from '../../lib/hooks/useBidData';
+import { HistoryList } from '../../features/view-nft/HistoryList/HistoryList';
+import { TokenHashInfo } from '../../features/view-nft/TokenHashInfo/TokenHashInfo';
+import { NFTMetrics } from '../../features/view-nft/NFTMetrics/NFTMetrics';
+import { DomainPreview } from '../../features/domain-preview/DomainPreview';
+import { Actions } from '../../features/view-nft/Actions/Actions';
 
 //- Library Imports
 import { Domain, DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
@@ -18,14 +14,14 @@ import { Domain, DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 //- Types Imports
 import { Metadata } from '../../lib/types/metadata';
 
-type NFTContainerProps = {
+type NFTProps = {
 	domain: Domain;
 	metrics: DomainMetrics;
 	domainMetadata: Metadata;
 	paymentTokenInfo: TokenPriceInfo;
 };
 
-const NFTContainer: FC<NFTContainerProps> = ({
+export const NFT: FC<NFTProps> = ({
 	domain,
 	metrics,
 	domainMetadata,
@@ -59,5 +55,3 @@ const NFTContainer: FC<NFTContainerProps> = ({
 		</>
 	);
 };
-
-export default NFTContainer;

--- a/src/pages/NFT/NFT.tsx
+++ b/src/pages/NFT/NFT.tsx
@@ -1,17 +1,13 @@
-//- React Imports
 import { FC } from 'react';
 
-//- Components Imports
 import { HistoryList } from '../../features/view-nft/HistoryList/HistoryList';
 import { TokenHashInfo } from '../../features/view-nft/TokenHashInfo/TokenHashInfo';
 import { NFTMetrics } from '../../features/view-nft/NFTMetrics/NFTMetrics';
 import { DomainPreview } from '../../features/domain-preview/DomainPreview';
 import { Actions } from '../../features/view-nft/Actions/Actions';
 
-//- Library Imports
 import { Domain, DomainMetrics, TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-//- Types Imports
 import { Metadata } from '../../lib/types/metadata';
 
 type NFTProps = {

--- a/src/pages/NFT/index.ts
+++ b/src/pages/NFT/index.ts
@@ -1,0 +1,1 @@
+export * from './NFT';


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/dApp-Team-Dash-78b824c0cd0e46c59c19dfe103ae929a?p=b3c46b48fefd4d3381d4a4881304dbb8&pm=s)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type

    - Refactoring



## 3. What is the old behaviour?
Default exports being used widely in code base.
StatsList mapping contains child UL tags
Comments for imports grouping


## 4. What is the new behaviour?
Removed and updated default exports
Moved StatsList UL tags higher than mapping
Removed comments
Removed unused vars


