### PR TITLE
fix: add button prop to grid card nft template and replace 'mock' button

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/zer0-os/zApp-NFTs.git"
-  	},
+	},
 	"main": "index.js",
 	"scripts": {
 		"clean": "rimraf dist && npx mkdirp dist",
@@ -72,7 +72,7 @@
 		"@ethersproject/units": "^5.6.1",
 		"@testing-library/jest-dom": "^5.16.5",
 		"@zero-tech/zns-sdk": "0.6.1",
-		"@zero-tech/zui": "0.7.0",
+		"@zero-tech/zui": "0.9.0",
 		"classnames": "^2.3.1",
 		"formik": "^2.2.9",
 		"moment": "^2.29.4",

--- a/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
+++ b/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
@@ -1,16 +1,15 @@
 import { FC } from 'react';
+
+import { useSubdomainData } from '../useSubdomainData';
+import { formatEthers } from '../../../lib/util/number/number';
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
 
-import { useDomainMetadata } from '../../../lib/hooks/useDomainMetadata';
-import { useDomainMetrics } from '../../../lib/hooks/useDomainMetrics';
-import { formatEthers } from '../../../lib/util/number/number';
-import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
-
+import { PlaceBidButton } from '../../place-bid';
+import { BuyNowButton } from '../../buy-now';
 import { GridCard } from '@zero-tech/zui/components/GridCard';
 import { NFT } from '@zero-tech/zui/components/GridCard/templates/NFT';
 
 import styles from './SubdomainTableCard.module.scss';
-import { useSubdomainData } from '../useSubdomainData';
 
 type SubdomainTableCardProps = {
 	domainId: string;
@@ -53,6 +52,8 @@ export const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 	const label =
 		(buyNowPriceString ? 'Buy Now' : 'Top Bid') + ' ' + paymentTokenLabel;
 
+	const button = buyNowPrice ? <BuyNowButton /> : <PlaceBidButton isRoot />;
+
 	return (
 		<GridCard
 			className={styles.Container}
@@ -68,15 +69,13 @@ export const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 					errorText: 'Failed to load!',
 				}}
 				zna={domainName}
-				onClickButton={() => console.log('yep')}
-				isButtonDisabled={isButtonDisabled}
-				buttonText={'Mock'}
 				label={label}
 				primaryText={{
 					text: buyNowPriceString ?? highestBidString,
 					isLoading: isMetricsLoading,
 				}}
 				secondaryText={''}
+				button={button}
 			/>
 		</GridCard>
 	);

--- a/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
+++ b/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
@@ -1,22 +1,15 @@
 import { FC } from 'react';
 
-import { ethers } from 'ethers';
+import { useSubdomainData } from '../useSubdomainData';
+import { formatEthers } from '../../../lib/util/number/number';
 import { TokenPriceInfo } from '@zero-tech/zns-sdk';
-
-import { useDomainMetadata } from '../../../lib/hooks/useDomainMetadata';
-import { useDomainMetrics } from '../../../lib/hooks/useDomainMetrics';
-import { formatEthers, formatNumber } from '../../../lib/util/number/number';
-import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
-
-import { SkeletonText } from '@zero-tech/zui/components/SkeletonText';
 
 import { PlaceBidButton } from '../../place-bid';
 import { BuyNowButton } from '../../buy-now';
-
+import { SkeletonText } from '@zero-tech/zui/components/SkeletonText';
 import { TableData } from '@zero-tech/zui/components/AsyncTable/Column';
 
 import styles from './SubdomainTableRow.module.scss';
-import { useSubdomainData } from '../useSubdomainData';
 
 type SubdomainTableRowProps = {
 	domainId: string;


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/zApp-NFTs-feedback-23ea6711e50f4cba8e3b62ce148e49e5?p=327e6eec65c34128a3947ec3e4eb3b4b&pm=s)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- bug fix of sorts (replace 'Mock' button on grid card)


## 3. What is the old behaviour?
Button incorrectly named and has no functionality
<img width="405" alt="Screenshot 2022-10-14 at 18 01 54" src="https://user-images.githubusercontent.com/39112648/195902129-813e8c16-36b1-4c60-99bd-10ba114e6859.png">

## 4. What is the new behaviour?
Button correctly named and has onClick functionality to open relevant modal
<img width="405" alt="Screenshot 2022-10-14 at 18 02 30" src="https://user-images.githubusercontent.com/39112648/195902229-2459a567-c582-46ce-aa5f-e3a747fea647.png">


