### PR TITLE
chore: increment version number - v0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-nfts",
-	"version": "0.2.2",
+	"version": "0.3.0",
 	"description": "zns marketplace app for zos",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
There have been a number of additions since the last version number and tag push. 
Bumping to v0.3.0.

- Increment version number