### PR TITLE
fix: undefined nft actions data

### DIFF
--- a/src/features/view-nft/Actions/Actions.tsx
+++ b/src/features/view-nft/Actions/Actions.tsx
@@ -1,5 +1,3 @@
-import { Domain, TokenPriceInfo } from '@zero-tech/zns-sdk';
-
 import { Action } from '..';
 import { BuyNowButton } from '../../buy-now';
 import { SetBuyNowButton } from '../../set-buy-now';
@@ -7,85 +5,67 @@ import { PlaceBidButton } from '../../place-bid';
 import { ViewBidsButton } from '../../view-bids';
 import { CancelBidButton } from '../../cancel-bid';
 
-import { DataTestId, Messages } from './Actions.constants';
-import { Labels } from '../../../lib/constants/labels';
-
 import { useWeb3 } from '../../../lib/hooks/useWeb3';
 import { useBuyNowPrice } from '../../../lib/hooks/useBuyNowPrice';
 import { useBidData } from '../../../lib/hooks/useBidData';
-
-import {
-	getOrderedActions,
-	getUsdConversion,
-	getVisibleActions,
-} from './Actions.utils';
-import { formatNumber } from '../../../lib/util/number/number';
-import { getHighestBid, getUserBids } from '../../../lib/util/bids/bids';
-
-import { ActionBlock, ActionTypes } from './Actions.types';
+import { useDomainMetrics } from '../../../lib/hooks/useDomainMetrics';
+import { formatEthers, formatNumber } from '../../../lib/util/number/number';
+import { getUserBids } from '../../../lib/util/bids/bids';
 import { Metadata } from '../../../lib/types/metadata';
+import { Labels } from '../../../lib/constants/labels';
+import { Domain } from '@zero-tech/zns-sdk';
+
+import { DataTestId } from './Actions.constants';
+import { ActionBlock, ActionTypes } from './Actions.types';
+import { getOrderedActions, getVisibleActions } from './Actions.utils';
 
 import styles from './Actions.module.scss';
 
 type ActionsProps = {
 	domain?: Domain;
 	domainMetadata?: Metadata;
-	paymentTokenInfo?: TokenPriceInfo;
 };
 
-export const Actions = ({
-	domain,
-	domainMetadata,
-	paymentTokenInfo,
-}: ActionsProps) => {
+export const Actions = ({ domain, domainMetadata }: ActionsProps) => {
 	const { account } = useWeb3();
-	const { data: buyNowPrice } = useBuyNowPrice(domain?.id);
+	const { data: buyNowPriceData } = useBuyNowPrice(domain?.id);
+	const { data: metrics } = useDomainMetrics(domain?.id);
 	const { data: bids } = useBidData(domain?.id);
-	const userBids = getUserBids(account, bids);
-	const highestBid = getHighestBid(bids);
-	const highestUserBid = getHighestBid(userBids);
+
+	const buyNowPrice = buyNowPriceData ? formatNumber(buyNowPriceData) : '-';
+	const userBids = getUserBids(account, bids) ?? [];
+	const highestUserBid =
+		userBids.length > 0 ? formatEthers(userBids[0]?.amount) : '-';
+	const highestBid =
+		metrics?.highestBid > '0' ? formatEthers(metrics?.highestBid) : '-';
+
 	const isOwnedByUser = domain?.owner?.toLowerCase() === account?.toLowerCase();
 	const isBiddable = !isOwnedByUser || Boolean(domainMetadata?.isBiddable);
-	const isUserBid = !isOwnedByUser && Boolean(highestUserBid);
+	const isUserBid = !isOwnedByUser && userBids.length > 0;
 	const isSetBuyNow = isOwnedByUser && Boolean(domain?.name);
 	const isBuyNow =
-		Boolean(buyNowPrice) && !isOwnedByUser && Boolean(domain?.name);
+		Boolean(buyNowPriceData) && !isOwnedByUser && Boolean(domain?.name);
 	const isViewBids =
 		isOwnedByUser !== undefined && isBiddable && bids?.length > 0;
 
 	const actions: { [action in ActionTypes]: ActionBlock } = {
 		[ActionTypes.BUY_NOW]: {
-			label: `${Labels.BUY_NOW} (${paymentTokenInfo?.name})`,
-			amountToken: formatNumber(buyNowPrice),
-			amountUsd: getUsdConversion(
-				buyNowPrice,
-				paymentTokenInfo?.price,
-				Messages.NO_BUY_NOW,
-			),
+			label: `${Labels.BUY_NOW}`,
+			amountToken: buyNowPrice,
 			isVisible: isBuyNow,
 			dataTestId: DataTestId.BUY_NOW,
 			buttonComponent: <BuyNowButton />,
 		},
 		[ActionTypes.SET_BUY_NOW]: {
-			label: `${Labels.BUY_NOW} (${paymentTokenInfo?.name})`,
-			amountToken: buyNowPrice ? formatNumber(buyNowPrice) : '-',
-			amountUsd: getUsdConversion(
-				buyNowPrice,
-				paymentTokenInfo?.price,
-				Messages.NO_BUY_NOW,
-			),
+			label: `${Labels.BUY_NOW}`,
+			amountToken: buyNowPrice,
 			isVisible: isSetBuyNow,
 			dataTestId: DataTestId.SET_BUY_NOW,
 			buttonComponent: <SetBuyNowButton />,
 		},
 		[ActionTypes.BID]: {
-			label: `${Labels.HIGHEST_BID} (${paymentTokenInfo?.name})`,
-			amountToken: highestBid > 0 ? highestBid : '-',
-			amountUsd: getUsdConversion(
-				highestBid,
-				paymentTokenInfo?.price,
-				Messages.NO_BIDS_PLACED,
-			),
+			label: `${Labels.HIGHEST_BID}`,
+			amountToken: highestBid,
 			isVisible: isBiddable || isViewBids,
 			dataTestId: DataTestId.BID,
 			buttonComponent: !isOwnedByUser ? (
@@ -97,9 +77,8 @@ export const Actions = ({
 			),
 		},
 		[ActionTypes.USER_BID]: {
-			label: `${Labels.YOUR_BID} (${paymentTokenInfo?.name})`,
-			amountToken: highestUserBid ? highestUserBid : '-',
-			amountUsd: getUsdConversion(highestBid, paymentTokenInfo?.price),
+			label: `${Labels.YOUR_BID}`,
+			amountToken: highestUserBid,
 			isVisible: isUserBid,
 			dataTestId: DataTestId.USER_BID,
 			buttonComponent: <CancelBidButton />,

--- a/src/features/view-nft/Actions/Actions.types.ts
+++ b/src/features/view-nft/Actions/Actions.types.ts
@@ -10,7 +10,7 @@ export enum ActionTypes {
 export type ActionBlock = {
 	label: string;
 	amountToken: number | string;
-	amountUsd: number | string;
+	amountUsd?: number | string;
 	isVisible: boolean;
 	dataTestId: string;
 	shouldShowBorder?: boolean;

--- a/src/lib/util/bids/bids.ts
+++ b/src/lib/util/bids/bids.ts
@@ -1,18 +1,15 @@
+import { BigNumber } from 'ethers';
 import { Bid } from '@zero-tech/zns-sdk/lib/zAuction';
 
-import { formatEthers } from '../../../lib/util/number/number';
-
-export const getHighestBid = (bids: Bid[]) =>
-	Math.max.apply(
-		null,
-		bids?.length > 0
-			? bids?.map((bid) => Number(formatEthers(bid.amount)))
-			: [null],
+export const sortBidsByAmount = (bids: Bid[]) => {
+	return bids?.sort((a, b) =>
+		BigNumber.from(a.amount).gte(BigNumber.from(b.amount)) ? -1 : 1,
 	);
+};
 
 export const getUserBids = (accountId: string, bids: Bid[]) => {
 	const userBids = bids?.filter(
 		(b) => b.bidder.toLowerCase() === accountId?.toLowerCase(),
 	);
-	return userBids;
+	return sortBidsByAmount(userBids);
 };


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/zApp-NFTs-feedback-23ea6711e50f4cba8e3b62ce148e49e5?p=d2554f3a5f534954902d9de4a91f507d&pm=s)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type

 - Bugfix



## 3. What is the old behaviour?
<!-- Please describe the old behaviour that you are modifying. -->
Undefined text visible on NFT Actions - this is due to payment token symbol being undefined due to network.
Data values not displaying as expected.

## 4. What is the new behaviour?
<!-- Please describe the behaviour or changes that are being added by this PR. -->
Correct values displaying under actions data
Removed use of payment token for now to prevent undefined token symbol text

<img width="429" alt="Screenshot 2022-10-18 at 11 17 08" src="https://user-images.githubusercontent.com/39112648/196403630-6311ece5-888c-4e7e-b8b1-9d48bfcf186c.png">

