### PR TITLE
chore: bump version 0.4.4 -> 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@zero-tech/zapp-nfts",
-	"version": "0.4.4",
+	"version": "0.5.0",
 	"description": "zns marketplace app for zos",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
With the merging of Place Bid feature, version is to be bumped from 0.4.4 -> 0.5.0
