### PR TITLE
fix(subdomain-card): incorrect metric label

### DIFF
--- a/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
+++ b/src/features/view-subdomains/SubdomainTableCard/SubdomainTableCard.tsx
@@ -33,10 +33,8 @@ export const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 		zna,
 	});
 
-	const buyNowPriceString = buyNowPrice ? buyNowPrice : highestBid;
-
-	const label =
-		(buyNowPriceString ? 'Buy Now' : 'Top Bid') + ' ' + paymentTokenLabel;
+	const metric = buyNowPrice ? buyNowPrice : highestBid;
+	const label = (buyNowPrice ? 'Buy Now' : 'Top Bid') + ' ' + paymentTokenLabel;
 
 	const button = buyNowPrice ? (
 		<BuyNowButton />
@@ -71,7 +69,7 @@ export const SubdomainTableCard: FC<SubdomainTableCardProps> = ({
 				zna={zna}
 				label={label}
 				primaryText={{
-					text: buyNowPriceString,
+					text: metric,
 					isLoading: isLoadingMetrics,
 				}}
 				secondaryText={''}


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/NFT-cards-are-incorrectly-saying-Buy-Now-instead-of-Top-Bid-25d17bdc70cf4e9390e60c3222950c57)