### PR TITLE
fix(subdomain-row): click modal shouldn't fire row click

### DIFF
--- a/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
+++ b/src/features/view-subdomains/SubdomainTableRow/SubdomainTableRow.tsx
@@ -35,8 +35,10 @@ export const SubdomainTableRow: FC<SubdomainTableRowProps> = ({
 	});
 
 	const handleOnClick = useCallback(
-		(e) => {
-			onClick(e, zna);
+		(event: any) => {
+			if (event.currentTarget.contains(event.target)) {
+				onClick(event, zna);
+			}
 		},
 		[zna, onClick],
 	);


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/4985d8ec0c2f4eb4860678eec483e6f6?v=7fd94d39937343aa983ac94b7d7034d5&p=6aad3798761943c0879bebb02226f3be&pm=s)

Similar to SubdomainTableCard, SubdomainTableRow click modal shouldn't fire the row click.

