### PR TITLE
chore: add npmrc

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@zer0-os:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Adds `npmrc` to prevent `401` when installing deps on CI or machine with no global `npmrc`.