### PR TITLE
fix: use nft view video when available

### DIFF
--- a/src/features/accept-bid/useAcceptBidData.ts
+++ b/src/features/accept-bid/useAcceptBidData.ts
@@ -19,7 +19,8 @@ export const useAcceptBidData = (zna: string) => {
 	const creator = domain?.minter;
 	const highestBid = metrics?.highestBid;
 	const isMetadataLocked = domain?.isLocked ? 'Locked' : 'Unlocked';
-	const imageSrc = metadata?.previewImage ?? metadata?.image;
+	const imageSrc =
+		metadata?.animation_url || metadata?.image_full || metadata?.image || '';
 	const imageAlt = `${metadata?.title ?? 'loading'} nft image`;
 	const paymentTokenSymbol = paymentToken?.symbol ?? '';
 	const paymentTokenId = paymentToken?.id ?? '';

--- a/src/features/cancel-bid/useCancelBidData.ts
+++ b/src/features/cancel-bid/useCancelBidData.ts
@@ -32,7 +32,8 @@ export const useCancelBidData = (zna: string) => {
 	const title = metadata?.title;
 	const creator = domain?.minter;
 	const balanceAsString = tokenBalance?.balanceAsString ?? '';
-	const imageSrc = metadata?.previewImage ?? metadata?.image;
+	const imageSrc =
+		metadata?.animation_url || metadata?.image_full || metadata?.image || '';
 	const imageAlt = `${metadata?.title ?? 'loading'} nft image`;
 	const paymentTokenSymbol = paymentToken?.symbol ?? '';
 	const isLeadingBid = highestUserBid?.amount > highestBid?.amount;

--- a/src/features/place-bid/usePlaceBidData.ts
+++ b/src/features/place-bid/usePlaceBidData.ts
@@ -25,7 +25,8 @@ export const usePlaceBidData = (zna: string) => {
 	const creator = domain?.minter;
 	const highestBid = metrics?.highestBid;
 	const balanceAsString = tokenBalance?.balanceAsString ?? '';
-	const imageSrc = metadata?.previewImage ?? metadata?.image;
+	const imageSrc =
+		metadata?.animation_url || metadata?.image_full || metadata?.image || '';
 	const imageAlt = `${metadata?.title ?? 'loading'} nft image`;
 	const paymentTokenSymbol = paymentToken?.symbol ?? '';
 	const paymentTokenId = paymentToken?.id ?? '';

--- a/src/features/transfer-ownership/useTransferOwnershipData.ts
+++ b/src/features/transfer-ownership/useTransferOwnershipData.ts
@@ -18,7 +18,8 @@ export const useTransferOwnershipData = (zna: string) => {
 
 	const title = metadata?.title;
 	const creator = domain?.minter;
-	const imageSrc = metadata?.previewImage ?? metadata?.image;
+	const imageSrc =
+		metadata?.animation_url || metadata?.image_full || metadata?.image || '';
 	const imageAlt = `${metadata?.title ?? 'loading'} nft image`;
 	const paymentTokenSymbol = paymentToken?.symbol ?? '';
 

--- a/src/features/view-nft/NFTBannerContainer/NFTBannerContainer.tsx
+++ b/src/features/view-nft/NFTBannerContainer/NFTBannerContainer.tsx
@@ -19,7 +19,9 @@ export const NFTBannerContainer: FC<BannerProps> = ({ zna }) => {
 	const altTemplate = `${metadata?.title ?? zna} nft `;
 
 	const bannerAlt = altTemplate + ` banner`;
-	const bannerSrc = metadata?.image_full ?? metadata?.image;
+
+	const bannerSrc =
+		metadata?.animation_url || metadata?.image_full || metadata?.image || '';
 
 	return (
 		<div className={styles.Banner}>


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/4985d8ec0c2f4eb4860678eec483e6f6?v=2de07237786c4d62830797da093e6a04&p=ff8c750e887f4e59ad0eaf2167366422&pm=s)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- fix


## 3. What is the old behaviour?
NFT image showing in place of NFT video on the NFT view page
- beasts
- kicks
- crafts

## 4. What is the new behaviour?

<img width="1168" alt="Screenshot 2022-12-12 at 14 39 14" src="https://user-images.githubusercontent.com/39112648/207073086-d80923cc-55cc-4bb5-919b-087edc83cf07.png">

<img width="1168" alt="Screenshot 2022-12-12 at 14 39 47" src="https://user-images.githubusercontent.com/39112648/207073212-6d1f05a5-83bb-4295-8359-7501513089bc.png">

<img width="1168" alt="Screenshot 2022-12-12 at 14 40 04" src="https://user-images.githubusercontent.com/39112648/207073255-48e48938-6c0d-41d8-bb0f-edfc9996102e.png">
