### PR TITLE
fix: resolve nft view page content height and overflow issue

### DIFF
--- a/src/pages/NFT/NFT.module.scss
+++ b/src/pages/NFT/NFT.module.scss
@@ -5,6 +5,7 @@
 
 	.Content {
 		margin-top: 1rem;
+		height: unset;
 
 		> * {
 			&:first-child {


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://www.notion.so/zerotech/4985d8ec0c2f4eb4860678eec483e6f6?v=2de07237786c4d62830797da093e6a04&p=a03e682efa2f4d78a03869e23b28a4d0&pm=s)

-----

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->
- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card


## 2. PR type
- bugfix

## 3. What is the old behaviour?
<img width="1425" alt="Screenshot 2022-12-12 at 16 15 52" src="https://user-images.githubusercontent.com/39112648/207096813-05311b84-4964-4248-9e3e-b6ceeeba2c86.png">

## 4. What is the new behaviour?
<img width="1425" alt="Screenshot 2022-12-12 at 16 16 38" src="https://user-images.githubusercontent.com/39112648/207096997-52db2fda-9488-4862-ae65-ba3364cc6e6c.png">

