### PR TITLE
fix: update zns-sdk and subdomain retrieval

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@zer0-os/zapp-scripts": "^0.0.3",
 				"@zero-tech/zapp-utils": "0.5.5",
 				"@zero-tech/zero-contracts": "^0.0.7",
-				"@zero-tech/zns-sdk": "0.9.1",
+				"@zero-tech/zns-sdk": "0.10.1",
 				"@zero-tech/ztoken-sdk": "^0.0.3",
 				"@zero-tech/zui": "0.15.0",
 				"classnames": "^2.3.1",
@@ -6418,9 +6418,9 @@
 			}
 		},
 		"node_modules/@zero-tech/zns-sdk": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zns-sdk/-/zns-sdk-0.9.1.tgz",
-			"integrity": "sha512-39LSfj6Nlin6+Ce1K1M6XQ1EjxQwgSgOt1rRnd1nS1Bwa6fMo17WBfqKOcojebEgWNAibO6x6Et53RxvBI+dzA==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zns-sdk/-/zns-sdk-0.10.1.tgz",
+			"integrity": "sha512-180P+EpN1qlL7Mk63ZDGx6AicxWNkGXZEMsi1zIQfULMn++xlTvbD0W6LNQ7TIJP1hNnuF4hh14tzk3KJU5V5Q==",
 			"dependencies": {
 				"@apollo/client": "3.4.10",
 				"@ethersproject/abi": "5.4.1",
@@ -22345,9 +22345,9 @@
 			}
 		},
 		"@zero-tech/zns-sdk": {
-			"version": "0.9.1",
-			"resolved": "https://registry.npmjs.org/@zero-tech/zns-sdk/-/zns-sdk-0.9.1.tgz",
-			"integrity": "sha512-39LSfj6Nlin6+Ce1K1M6XQ1EjxQwgSgOt1rRnd1nS1Bwa6fMo17WBfqKOcojebEgWNAibO6x6Et53RxvBI+dzA==",
+			"version": "0.10.1",
+			"resolved": "https://registry.npmjs.org/@zero-tech/zns-sdk/-/zns-sdk-0.10.1.tgz",
+			"integrity": "sha512-180P+EpN1qlL7Mk63ZDGx6AicxWNkGXZEMsi1zIQfULMn++xlTvbD0W6LNQ7TIJP1hNnuF4hh14tzk3KJU5V5Q==",
 			"requires": {
 				"@apollo/client": "3.4.10",
 				"@ethersproject/abi": "5.4.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
 		"@zer0-os/zapp-scripts": "^0.0.3",
 		"@zero-tech/zapp-utils": "0.5.5",
 		"@zero-tech/zero-contracts": "^0.0.7",
-		"@zero-tech/zns-sdk": "0.9.1",
+		"@zero-tech/zns-sdk": "0.10.1",
 		"@zero-tech/ztoken-sdk": "^0.0.3",
 		"@zero-tech/zui": "0.15.0",
 		"classnames": "^2.3.1",

--- a/src/features/view-subdomains/SubdomainTable/useInfiniteSubdomains.ts
+++ b/src/features/view-subdomains/SubdomainTable/useInfiniteSubdomains.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect } from 'react';
 import { InfiniteData, useInfiniteQuery, useQueryClient } from 'react-query';
 
 import { useZnsSdk } from '../../../lib/hooks';
-import { getDomainId } from '../../../lib/util';
 import { DomainSortOptions } from '@zero-tech/zns-sdk/lib/api/dataStoreApi/types';
+import { useZna } from '../../../lib/hooks/useZna';
 
 /**
  * Number of results to show per page.
@@ -34,11 +34,11 @@ export const getInfiniteSubdomainQueryKey = (parentDomainId: string) => {
 export const useInfiniteSubdomains = (zna: string) => {
 	const sdk = useZnsSdk();
 
-	const parentDomainId = getDomainId(zna);
+	const { domainId } = useZna(zna);
 	const queryClient = useQueryClient();
 
 	// Assigning queryKey here as it's used in multiple places
-	const queryKey = getInfiniteSubdomainQueryKey(parentDomainId);
+	const queryKey = getInfiniteSubdomainQueryKey(domainId);
 
 	/**
 	 * Fetches the next page of subdomains from the data store
@@ -49,14 +49,14 @@ export const useInfiniteSubdomains = (zna: string) => {
 			const currentIndex = pageParam * DEFAULT_RESULTS_PER_PAGE;
 
 			return await sdk.getSubdomainsById(
-				parentDomainId,
+				domainId,
 				SHOULD_USE_DATA_STORE,
 				DEFAULT_RESULTS_PER_PAGE,
 				currentIndex,
 				DEFAULT_SORT_OPTIONS,
 			);
 		},
-		[parentDomainId, sdk],
+		[domainId, sdk],
 	);
 
 	// Note: assigning query to variable so we can destructure it in hook return
@@ -90,7 +90,7 @@ export const useInfiniteSubdomains = (zna: string) => {
 				}
 			});
 		};
-	}, [parentDomainId]);
+	}, [domainId]);
 
 	return {
 		...query,


### PR DESCRIPTION
- Bump `zns-sdk` version
- Use `domainId` rather than `parentDomainId`