### PR TITLE
fix: temporarily remove subdomain metrics stat widgets

### DIFF
--- a/src/features/view-subdomains/ViewSubdomains.tsx
+++ b/src/features/view-subdomains/ViewSubdomains.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { SubdomainMetrics } from './SubdomainMetrics';
 import { SubdomainTable } from './SubdomainTable';
 
 import { SubdomainViewSelector } from './selectors';
@@ -12,7 +11,6 @@ interface ViewSubdomainsProps {
 export const ViewSubdomains = ({ zna }: ViewSubdomainsProps) => {
 	return (
 		<section data-testid={SubdomainViewSelector.VIEW_SUBDOMAINS_SECTION}>
-			<SubdomainMetrics zna={zna} />
 			<SubdomainTable zna={zna} />
 		</section>
 	);


### PR DESCRIPTION
<!-- NOTE: Please use the following template - it makes the reviewer's lives much easier! -->

[Associated Notion Card](https://wilderworld.atlassian.net/jira/software/c/projects/ZAP/boards/34?modal=detail&selectedIssue=ZAP-167)

---

## 1. Pull request checklist

<!-- Please make sure to do the following - your PR may not be accepted if any of these aren't completed: -->

- [x] Notion card has been moved to the Code Review column
- [x] Notion card has a link to this PR
- [x] A reviewer has been assigned to the Notion card

## 2. PR type
- fix (temporary)

## 3. What is the old behaviour?
Due to retrieving metrics data from available data store endpoints, the loading time gives the impression that something is broken.

Loom detailing the issue: [Metrics](https://www.loom.com/share/4d7ff9d9f2c44442a8693d945e8cb30a)

## 4. What is the new behaviour?
- remove subdomain stat widgets 

